### PR TITLE
progress: fix segmentation fault when TERM variable is "dumb"

### DIFF
--- a/progress/progress.c
+++ b/progress/progress.c
@@ -318,7 +318,8 @@ progress_bar_set (struct progress_bar *bar,
        * (b) it's just not possible to use tputs in a sane way here.
        */
       /*tputs (UP, 2, putchar);*/
-      fprintf (fp, "%s", UP);
+      if (UP)
+        fprintf (fp, "%s", UP);
     }
     bar->count++;
 


### PR DESCRIPTION
virt-resize command results in segmentation fault when TERM environment variable is "dumb":

    # TERM="dumb" virt-resize ./rhel-8.7-x86_64-kvm.qcow2 \
    => ./rhel-8.7-kvm.qcow2 \
    => --resize /dev/sda3=20G
    [   0.0] Examining ./rhel-8.7-x86_64-kvm.qcow2
    **********
    ...snip...
    **********
    [   6.4] Setting up initial partition table on ./rhel-8.7-kvm.qcow2
    [  19.9] Copying /dev/sda1
    [  20.0] Copying /dev/sda2
    [  20.1] Copying /dev/sda3
    -  2% [###-------------...snip...-------------------] --:--
    Segmentation fault

This issue was introduced by the commit
911a16a9fa965ce8defb3307f6bf338f5d2d5c94 (fish: progress bar: Send interactive progress bar output to /dev/tty (RHBZ#859875).) that lacked the care for UP variable to be NULL depending on the terminal type. As a result, trying to print UP variable results in NULL pointer dereference when UP variable is NULL. In particular, UP variable is set to NULL if TERM variable is "dumb". On the other hand, ncurses's tputs() that was originally used until the commit takes care for NULL string.

To fix this issue, add a NULL check for UP variable before printing it.

Note that I found this issue when I ran virt-resize command in emacs shell-mode where TERM variable is set to "dumb".