### PR TITLE
mldrivers/linux.ml: delete `Remove`

### DIFF
--- a/mldrivers/linux.ml
+++ b/mldrivers/linux.ml
@@ -30,32 +30,6 @@ let augeas_reload g =
   g#aug_load ();
   debug_augeas_errors g
 
-let rec remove g root packages =
-  if packages <> [] then (
-    do_remove g root packages;
-    (* Reload Augeas in case anything changed. *)
-    augeas_reload g
-  )
-
-and do_remove g root packages =
-  assert (List.length packages > 0);
-
-  let package_format = g#inspect_get_package_format root in
-  match package_format with
-  | "deb" ->
-    let cmd = [ "dpkg"; "--purge" ] @ packages in
-    let cmd = Array.of_list cmd in
-    ignore (g#command cmd);
-
-  | "rpm" ->
-    let cmd = [ "rpm"; "-e"; "--allmatches" ] @ packages in
-    let cmd = Array.of_list cmd in
-    ignore (g#command cmd)
-
-  | format ->
-    error (f_"don’t know how to remove packages using %s: packages: %s")
-      format (String.concat " " packages)
-
 let file_list_of_package (g : Guestfs.guestfs) root app =
   let package_format = g#inspect_get_package_format root in
   match package_format with

--- a/mldrivers/linux.mli
+++ b/mldrivers/linux.mli
@@ -23,9 +23,6 @@ val augeas_reload : Guestfs.guestfs -> unit
     additional debugging information about parsing problems
     that augeas found. *)
 
-val remove : Guestfs.guestfs -> string -> string list -> unit
-(** [remove g root pkgs] uninstalls the package(s). *)
-
 val file_list_of_package : Guestfs.guestfs -> string ->
                            Guestfs.application2 -> string list
 (** [file_list_of_package g root app] returns the list of files


### PR DESCRIPTION
Last usages were removed in
https://github.com/libguestfs/virt-v2v/commit/b3268a13beca4da218e7ffe4648a18420296103a