### PR TITLE
Handle large rpm -ql output

### DIFF
--- a/mlstdutils/std_utils.ml
+++ b/mlstdutils/std_utils.ml
@@ -98,24 +98,27 @@ module String = struct
       and len = length str in
       len >= sufflen && sub str (len - sufflen) sufflen = suffix
 
-    let rec find s sub =
-      let len = length s in
+    let find_from str pos sub =
       let sublen = length sub in
-      let rec loop i =
-        if i <= len-sublen then (
-          let rec loop2 j =
-            if j < sublen then (
-              if s.[i+j] = sub.[j] then loop2 (j+1)
-              else -1
-            ) else
-              i (* found *)
-          in
-          let r = loop2 0 in
-          if r = -1 then loop (i+1) else r
-        ) else
-          -1 (* not found *)
-      in
-      loop 0
+      if sublen = 0 then
+        0
+      else (
+        let found = ref 0 in
+        let len = length str in
+        try
+          for i = pos to len - sublen do
+            let j = ref 0 in
+            while unsafe_get str (i + !j) = unsafe_get sub !j do
+              incr j;
+              if !j = sublen then begin found := i; raise Exit; end;
+            done;
+          done;
+          -1
+        with
+          Exit -> !found
+      )
+
+    let find str sub = find_from str 0 sub
 
     let rec replace s s1 s2 =
       let len = length s in

--- a/mlstdutils/std_utils.mli
+++ b/mlstdutils/std_utils.mli
@@ -82,6 +82,10 @@ module String : sig
     val find : string -> string -> int
     (** [find str sub] searches for [sub] as a substring of [str].  If
         found it returns the index.  If not found, it returns [-1]. *)
+    val find_from : string -> int -> string -> int
+    (** [find_from str start sub] searches for [sub] as a substring of [str],
+        starting at index [start].  If found it returns the index.
+        If not found, it returns [-1]. *)
     val replace : string -> string -> string -> string
     (** [replace str s1 s2] replaces all instances of [s1] appearing in
         [str] with [s2]. *)

--- a/mlstdutils/std_utils_tests.ml
+++ b/mlstdutils/std_utils_tests.ml
@@ -113,13 +113,19 @@ let test_string_nsplit ctx =
   assert_equal_stringlist [""] (String.nsplit " " "");
   assert_equal_stringlist ["abc"] (String.nsplit " " "abc");
   assert_equal_stringlist ["a"; "b"; "c"] (String.nsplit " " "a b c");
+  assert_equal_stringlist ["abc"; "d"; "e"] (String.nsplit " " "abc d e");
   assert_equal_stringlist ["a"; "b"; "c"; ""] (String.nsplit " " "a b c ");
   assert_equal_stringlist [""; "a"; "b"; "c"] (String.nsplit " " " a b c");
   assert_equal_stringlist [""; "a"; "b"; "c"; ""] (String.nsplit " " " a b c ");
   assert_equal_stringlist ["a b c d"] (String.nsplit ~max:1 " " "a b c d");
   assert_equal_stringlist ["a"; "b c d"] (String.nsplit ~max:2 " " "a b c d");
   assert_equal_stringlist ["a"; "b"; "c d"] (String.nsplit ~max:3 " " "a b c d");
-  assert_equal_stringlist ["a"; "b"; "c"; "d"] (String.nsplit ~max:10 " " "a b c d")
+  assert_equal_stringlist ["a"; "b"; "c"; "d"] (String.nsplit ~max:10 " " "a b c d");
+
+  (* Test that nsplit can handle large strings. *)
+  let xs = Array.to_list (Array.make 10_000_000 "xyz") in
+  let xs_concat = String.concat " " xs in
+  assert_equal_stringlist xs (String.nsplit " " xs_concat)
 
 (* Test Std_utils.String.lines_split. *)
 let test_string_lines_split ctx =


### PR DESCRIPTION
@crobinso 

Fix for https://issues.redhat.com/browse/RHEL-80080

Prerequisite: https://github.com/libguestfs/libguestfs/pull/171

It's possible (albeit a bit annoying) to test this without installing a new libguestfs.  Assuming libguestfs with the patch above is in an adjacent directory, you have to:
 * dnf remove `ocaml-libguestfs` package, if that is installed, since for some reason while linking it may pick the wrong OCaml library.
 * Configure virt-v2v using `../libguestfs/run ./configure`
 * `../libguestfs/run make clean`
 * Build virt-v2v using `../libguestfs/run make`
 * Test using `../libguestfs/run virt-v2v ...`

This requires an additional small patch to virt-v2v which I will push separately after review:
```
diff --git a/m4/guestfs-libraries.m4 b/m4/guestfs-libraries.m4
index b8a64beac7d..4a792c60544 100644
--- a/m4/guestfs-libraries.m4
+++ b/m4/guestfs-libraries.m4
@@ -18,7 +18,7 @@
 dnl Any C libraries required by virt-v2v.
 
 dnl Of course we need libguestfs.
-PKG_CHECK_MODULES([LIBGUESTFS], [libguestfs >= 1.44])
+PKG_CHECK_MODULES([LIBGUESTFS], [libguestfs >= 1.55.6])
 
 dnl And libnbd.
 PKG_CHECK_MODULES([LIBNBD], [libnbd >= 1.14])
```