### PR TITLE
Couple tweaks to installed virtio-win drivers

### DIFF
--- a/mlcustomize/inject_virtio_win.ml
+++ b/mlcustomize/inject_virtio_win.ml
@@ -527,10 +527,16 @@ and virtio_iso_path_matches_guest_os t path =
       else
         raise Not_found in
 
-    let p_sriov = pathelem "sriov" in
+    (* https://issues.redhat.com/browse/RHEL-56383
+     * sriov/ dir can have files that conflict with netkvm driver install.
+     *)
+    let p_sriov =
+      String.find path "vioprot." >= 0 ||
+      pathelem "sriov"
+    in
 
     arch = p_arch &&
-    not p_sriov && (* always ignored, see RHEL-56383 *)
+    not p_sriov &&
     os_major = p_os_major && os_minor = p_os_minor &&
     match_os_variant os_variant &&
     match_osinfo osinfo

--- a/mlcustomize/inject_virtio_win.ml
+++ b/mlcustomize/inject_virtio_win.ml
@@ -535,8 +535,14 @@ and virtio_iso_path_matches_guest_os t path =
       pathelem "sriov"
     in
 
+    (* .pdb files are debugging files. they are not part of the
+     * signed driver and are not necessary to install.
+     *)
+    let p_pdb = String.is_suffix path ".pdb" in
+
     arch = p_arch &&
     not p_sriov &&
+    not p_pdb &&
     os_major = p_os_major && os_minor = p_os_minor &&
     match_os_variant os_variant &&
     match_osinfo osinfo


### PR DESCRIPTION
This makes a couple tweaks to what we install for virtio-win drivers. See individual commits for details.

If this is merged, I can handle sending PR to update v2v submodule, since it will conflict with another PR I'm about to send which adds more test output