### PR TITLE
Remove use of libosinfo `drivers` metadata

### DIFF
--- a/mlcustomize/inject_virtio_win.ml
+++ b/mlcustomize/inject_virtio_win.ml
@@ -132,7 +132,7 @@ let rec inject_virtio_win_drivers ({ g } as t) reg =
   (* XXX Inelegant hack copied originally from [Convert_windows].
    * We should be able to work this into the code properly later.
    *)
-  let (machine : machine_type), virtio_1_0 =
+  let (machine : machine_type), _ =
     match t.i_arch with
     | ("i386"|"x86_64") ->
        (try
@@ -180,7 +180,7 @@ let rec inject_virtio_win_drivers ({ g } as t) reg =
       { block_driver = IDE; net_driver = RTL8139;
         virtio_rng = false; virtio_balloon = false;
         isa_pvpanic = false; virtio_socket = false;
-        machine; virtio_1_0; }
+        machine; virtio_1_0 = true; }
   )
   else (
     (* Can we install the block driver? *)
@@ -259,7 +259,7 @@ let rec inject_virtio_win_drivers ({ g } as t) reg =
       virtio_balloon = g#exists (driverdir // "balloon.inf");
       isa_pvpanic = g#exists (driverdir // "pvpanic.inf");
       virtio_socket = g#exists (driverdir // "viosock.inf");
-      machine; virtio_1_0;
+      machine; virtio_1_0 = true;
     }
   )
 

--- a/mltools/libosinfo-c.c
+++ b/mltools/libosinfo-c.c
@@ -191,25 +191,6 @@ v2v_osinfo_os_get_id (value osv)
   CAMLreturn (copyv);
 }
 
-static value
-glist_to_value_list (GList *list)
-{
-  CAMLparam0 ();
-  CAMLlocal3 (rv, v, copyv);
-  GList *l;
-
-  rv = Val_emptylist;
-  for (l = list; l != NULL; l = l->next) {
-    v = caml_alloc (2, 0);
-    copyv = caml_copy_string (l->data);
-    Store_field (v, 0, copyv);
-    Store_field (v, 1, rv);
-    rv = v;
-  }
-
-  CAMLreturn (rv);
-}
-
 /* Collect OsinfoDevice properties from two levels:
  *
  * - The OSINFO_ENTITY_PROP_ID property, originating from the OsinfoEntity base
@@ -272,65 +253,6 @@ v2v_osinfo_device_list_to_value_list (OsinfoDeviceList *dev_list)
   }
 
   CAMLreturn (retvalv);
-}
-
-value
-v2v_osinfo_os_get_device_drivers (value osv)
-{
-  CAMLparam1 (osv);
-  CAMLlocal4 (rv, v, vi, copyv);
-  OsinfoDeviceDriverList *list;
-  gint i, len;
-
-  list = osinfo_os_get_device_drivers (OsinfoOs_t_val (osv));
-  len = osinfo_list_get_length (OSINFO_LIST(list));
-
-  rv = Val_emptylist;
-  for (i = len - 1; i >= 0; --i) {
-    OsinfoDeviceDriver *driver;
-    const gchar *str;
-    gboolean b;
-    GList *l;
-    gint64 i64;
-    OsinfoDeviceList *dev_list;
-
-    driver = OSINFO_DEVICE_DRIVER(osinfo_list_get_nth (OSINFO_LIST(list), i));
-
-    vi = caml_alloc (7, 0);
-    str = osinfo_device_driver_get_architecture (driver);
-    copyv = caml_copy_string (str);
-    Store_field (vi, 0, copyv);
-    str = osinfo_device_driver_get_location (driver);
-    copyv = caml_copy_string (str);
-    Store_field (vi, 1, copyv);
-    b = osinfo_device_driver_get_pre_installable (driver);
-    Store_field (vi, 2, Val_bool (b));
-    b = osinfo_device_driver_get_signed (driver);
-    Store_field (vi, 3, Val_bool (b));
-#if IS_LIBOSINFO_VERSION(1, 7, 0)
-    i64 = osinfo_device_driver_get_priority (driver);
-#else
-    /* Same as OSINFO_DEVICE_DRIVER_DEFAULT_PRIORITY in libosinfo 1.7.0+. */
-    i64 = 50;
-#endif
-    copyv = caml_copy_int64 (i64);
-    Store_field (vi, 4, copyv);
-    l = osinfo_device_driver_get_files (driver);
-    Store_field (vi, 5, glist_to_value_list (l));
-    g_list_free (l);
-    dev_list = osinfo_device_driver_get_devices (driver);
-    v = (dev_list == NULL) ?
-        Val_emptylist :
-        v2v_osinfo_device_list_to_value_list (dev_list);
-    Store_field (vi, 6, v);
-
-    v = caml_alloc (2, 0);
-    Store_field (v, 0, vi);
-    Store_field (v, 1, rv);
-    rv = v;
-  }
-
-  CAMLreturn (rv);
 }
 
 value

--- a/mltools/libosinfo.ml
+++ b/mltools/libosinfo.ml
@@ -35,24 +35,12 @@ type osinfo_device = {
   subsystem : string;
 }
 
-type osinfo_device_driver = {
-  architecture : string;
-  location : string;
-  pre_installable : bool;
-  signed : bool;
-  priority : int64;
-  files : string list;
-  devices : osinfo_device list;
-}
-
 external osinfo_os_get_id : osinfo_os_t -> string = "v2v_osinfo_os_get_id"
-external osinfo_os_get_device_drivers : osinfo_os_t -> osinfo_device_driver list = "v2v_osinfo_os_get_device_drivers"
 external osinfo_os_get_devices : osinfo_os_t -> osinfo_device list = "v2v_osinfo_os_get_all_devices"
 
 class osinfo_os h =
   object (self)
     method get_id () = osinfo_os_get_id h
-    method get_device_drivers () = osinfo_os_get_device_drivers h
     method get_devices () = osinfo_os_get_devices h
 end
 

--- a/mltools/libosinfo.mli
+++ b/mltools/libosinfo.mli
@@ -32,21 +32,9 @@ type osinfo_device = {
   subsystem : string;
 }
 
-type osinfo_device_driver = {
-  architecture : string;
-  location : string;
-  pre_installable : bool;
-  signed : bool;
-  priority : int64;
-  files : string list;
-  devices : osinfo_device list;
-}
-
 class osinfo_os : osinfo_os_t -> object
   method get_id : unit -> string
   (** Return the ID. *)
-  method get_device_drivers : unit -> osinfo_device_driver list
-  (** Return the list of device drivers. *)
   method get_devices : unit -> osinfo_device list
   (** Return the list of devices. *)
 end

--- a/mltools/libosinfo_utils.ml
+++ b/mltools/libosinfo_utils.ml
@@ -68,52 +68,6 @@ let string_of_osinfo_device_list dev_list =
   String.concat "\n"
     (List.map (fun dev -> columnate (listify dev) max_widths) dev_list)
 
-let string_of_osinfo_device_driver { Libosinfo.architecture; location;
-                                     pre_installable; signed; priority;
-                                     files; devices } =
-  Printf.sprintf "%s: [%s, %s, %s, priority %Ld]\nFiles:\n%s\nDevices:\n%s"
-    location architecture
-    (if pre_installable then "pre-installable" else "not pre-installable")
-    (if signed then "signed" else "unsigned")
-    priority
-    (String.concat "\n" files)
-    (string_of_osinfo_device_list devices)
-
-let best_driver drivers arch =
-  let debug_drivers =
-    List.iter (fun d -> debug "Driver: %s" (string_of_osinfo_device_driver d))
-  (* The architecture that "inspect.i_arch" from libguestfs
-   * ("daemon/filearch.ml") calls "i386", the osinfo-db schema
-   * ("data/schema/osinfo.rng.in") calls "i686".
-   *)
-  and arch = if arch = "i386" then "i686" else arch in
-  debug "libosinfo drivers before filtering:";
-  debug_drivers drivers;
-  let drivers =
-    List.filter (
-      fun { Libosinfo.architecture; location; pre_installable } ->
-        if architecture <> arch || not pre_installable then
-          false
-        else
-          try
-            (match Xml.parse_uri location with
-            | { Xml.uri_scheme = Some scheme;
-                Xml.uri_path = Some _ } when scheme = "file" -> true
-            | _ -> false
-            )
-          with Invalid_argument _ -> false
-    ) drivers in
-  debug "libosinfo drivers after filtering:";
-  debug_drivers drivers;
-  let drivers =
-    List.sort (
-      fun { Libosinfo.priority = prioA } { Libosinfo.priority = prioB } ->
-        compare prioB prioA
-    ) drivers in
-  if drivers = [] then
-    raise Not_found;
-  List.hd drivers
-
 type os_support = {
   q35 : bool;
   vio10 : bool;

--- a/mltools/libosinfo_utils.mli
+++ b/mltools/libosinfo_utils.mli
@@ -28,21 +28,6 @@ val get_os_by_short_id : string -> Libosinfo.osinfo_os
 val string_of_osinfo_device_list : Libosinfo.osinfo_device list -> string
 (** Convert an [osinfo_device] list to a printable string for debugging. *)
 
-val string_of_osinfo_device_driver : Libosinfo.osinfo_device_driver -> string
-(** Convert a [osinfo_device_driver] to a printable string for debugging. *)
-
-val best_driver : Libosinfo.osinfo_device_driver list ->
-                  string ->
-                  Libosinfo.osinfo_device_driver
-(** [best_driver drivers arch] picks the best driver from [drivers] as follows:
-    - filters out drivers that:
-      - target a different architecture,
-      - are not pre-installable,
-      - have an invalid or non-local URL;
-    - sorts the remaining drivers by priority, like libosinfo does;
-    - picks the top driver of the sorted list.
-    Raises Not_found if no driver in [drivers] survives filtering. *)
-
 type os_support = {
   q35 : bool;
   vio10 : bool;


### PR DESCRIPTION
This addresses the bits I raised here: https://github.com/libguestfs/virt-v2v/issues/75

We stop using libosinfo `drivers` metadata and rip out all the plumbing for it. Outside of rare corner cases, the primary impact is we install more driver files for some cases, which I list in the issue. I think those are all harmless or arguably bug fixes.

`virt-customize --inject-virtio-win osinfo` now has no chance of finding drivers, but that will be handled separately.