### PR TITLE
mltools: decouple and simplify osinfo device support checks

### DIFF
--- a/mlcustomize/inject_virtio_win.ml
+++ b/mlcustomize/inject_virtio_win.ml
@@ -140,9 +140,7 @@ let rec inject_virtio_win_drivers ({ g } as t) reg =
           let devices = os#get_devices () in
           debug "libosinfo devices for OS \"%s\":\n%s" t.i_osinfo
             (Libosinfo_utils.string_of_osinfo_device_list devices);
-          let { Libosinfo_utils.q35; _ } =
-            Libosinfo_utils.os_support_of_osinfo_device_list devices in
-          (if q35 then Q35 else I440FX)
+          (if Libosinfo_utils.os_devices_supports_q35 devices then Q35 else I440FX)
         with
         | Not_found ->
            (* Pivot on the year 2007.  Any Windows version from earlier than

--- a/mltools/libosinfo_utils.ml
+++ b/mltools/libosinfo_utils.ml
@@ -68,20 +68,10 @@ let string_of_osinfo_device_list dev_list =
   String.concat "\n"
     (List.map (fun dev -> columnate (listify dev) max_widths) dev_list)
 
-type os_support = {
-  q35 : bool;
-  vio10 : bool;
-}
+let os_devices_supports_q35 devices =
+  List.exists
+    (fun { Libosinfo.id } -> id = "http://qemu.org/chipset/x86/q35") devices
 
-let os_support_of_osinfo_device_list =
-  let rec next accu left =
-    match accu, left with
-    | { q35 = true; vio10 = true }, _
-    | _ , [] ->
-      accu
-    | { q35; vio10 }, { Libosinfo.id } :: tail ->
-      let q35 = q35 || id = "http://qemu.org/chipset/x86/q35"
-      and vio10 = vio10 || id = "http://pcisig.com/pci/1af4/1041" in
-      next { q35; vio10 } tail
-  in
-  next { q35 = false; vio10 = false }
+let os_devices_supports_vio10 devices =
+  List.exists
+    (fun { Libosinfo.id } -> id = "http://pcisig.com/pci/1af4/1041") devices

--- a/mltools/libosinfo_utils.mli
+++ b/mltools/libosinfo_utils.mli
@@ -28,16 +28,8 @@ val get_os_by_short_id : string -> Libosinfo.osinfo_os
 val string_of_osinfo_device_list : Libosinfo.osinfo_device list -> string
 (** Convert an [osinfo_device] list to a printable string for debugging. *)
 
-type os_support = {
-  q35 : bool;
-  vio10 : bool;
-}
-(** Tell whether the operating system supports the Q35 board type and/or
-    non-transitional (virtio-1.0-only) virtio devices. (Internally, the
-    virtio-1.0-net device is used as a proxy for the general statement about
-    virtio-1.0.)
- *)
+val os_devices_supports_vio10 : Libosinfo.osinfo_device list -> bool
+(** Check [osinfo_device] list includes evidence of virtio-1.0. *)
 
-val os_support_of_osinfo_device_list : Libosinfo.osinfo_device list ->
-                                       os_support
-(** Get [os_support] from an [osinfo_device] list. *)
+val os_devices_supports_q35 : Libosinfo.osinfo_device list -> bool
+(** Check [osinfo_device] list includes q35. *)


### PR DESCRIPTION
Pairing the vio10 and q35 supports checks is a bit awkward. Break these apart into simpler functions.

This will require a patch on v2v side as well