### PR TITLE
mlcustomize/SELinux_relabel.ml: Relabel every mountpoint

### DIFF
--- a/mlcustomize/SELinux_relabel.ml
+++ b/mlcustomize/SELinux_relabel.ml
@@ -1,5 +1,5 @@
 (* virt-customize
- * Copyright (C) 2016 Red Hat Inc.
+ * Copyright (C) 2016-2025 Red Hat Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -114,4 +114,4 @@ and use_setfiles g =
   );
 
   (* Relabel everything. *)
-  g#selinux_relabel ~force:true specfile "/"
+  g#setfiles ~force:true specfile ["/"]

--- a/mlcustomize/SELinux_relabel.ml
+++ b/mlcustomize/SELinux_relabel.ml
@@ -113,5 +113,13 @@ and use_setfiles g =
     g#copy_attributes ~all:true old_specfile specfile
   );
 
+  (* Get the list of mountpoints, since setfiles does not cross
+   * filesystems (RHEL-108174).
+   *)
+  let mps = g#mountpoints () |>
+            List.map snd |>       (* the list of directories *)
+            List.sort compare |>  (* sort them for consistency *)
+            Array.of_list in
+
   (* Relabel everything. *)
-  g#setfiles ~force:true specfile ["/"]
+  g#setfiles ~force:true specfile mps

--- a/mlcustomize/SELinux_relabel.ml
+++ b/mlcustomize/SELinux_relabel.ml
@@ -24,6 +24,10 @@ open Printf
 
 module G = Guestfs
 
+(* XXX A lot of this code could usefully be moved into
+ * [libguestfs.git/daemon/selinux.ml].
+ *)
+
 let rec relabel (g : G.guestfs) =
   (* Is the guest using SELinux?  (Otherwise this is a no-op). *)
   if is_selinux_guest g then (


### PR DESCRIPTION
Note: Requires https://github.com/libguestfs/libguestfs/pull/209
@crobinso 

 It turns out that the SELinux `setfiles` command does not cross mountpoint boundaries.  We therefore have to pass in a list of mountpoints in order for setfiles to relabel everything.

For most existing guests this change is largely neutral, except that we will now pass `/sysroot/boot` to setfiles (as that is almost always a separate filesystem, and we ignored it before).

Fixes: https://issues.redhat.com/browse/RHEL-108174