### PR TITLE
mlcustomize: Drop setfiles -F flag

### DIFF
--- a/mlcustomize/SELinux_relabel.ml
+++ b/mlcustomize/SELinux_relabel.ml
@@ -122,4 +122,4 @@ and use_setfiles g =
             Array.of_list in
 
   (* Relabel everything. *)
-  g#setfiles ~force:true specfile mps
+  g#setfiles specfile mps


### PR DESCRIPTION
The setfiles -F flag is documented rather confusingly as:
```
  -F  Force reset of context to  match  file_context  for  customizable
      files,  and  the  default  file context, changing the user, role,
      range portion as well as the type.
```
"Customizable types" are an SELinux concept that I'm not very clear about it appears we expect local changes to be made, and for setfiles/fixfiles/restorecon not to reset the label back to default. Gentoo has this page about them:

  https://wiki.gentoo.org/wiki/SELinux/Tutorials/Working_with_customizable_types

It seems that we shouldn't try to modify these labels, and in particular it breaks podman rootless containers.  So drop the -F flag (confusingly called "~force:true").

More precisely, this will make flags->set_specctx be false in the following libselinux code:

  https://github.com/SELinuxProject/selinux/blob/3aac92b7250ed57fd4ab674ffcf03d9c499b3188/libselinux/src/selinux_restorecon.c#L738-L765

To test this change, I used virt-builder to create the following images:
```
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 08:48  rhel-7.1.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 08:49  rhel-7.3.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 08:50  rhel-7.7.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 08:50  rhel-7.9.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:02  rhel-7.5.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:04  rhel-8.1.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:11  rhel-8.3.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:13  rhel-8.5.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:14  rhel-8.7.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:14  rhel-8.9.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:14  rhel-9.1.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:14  rhel-9.3.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:14  rhel-10.1.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:15  fedora-20.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:15  fedora-30.img
  -rw-r--r--.  1 rjones rjones     6442450944 May 19 09:15  fedora-40.img
```
Then for each one, I ran:
```
  $ rm /var/tmp/pp/* ; \
    ./run virt-v2v -i disk /var/tmp/$image \
                   -o local -os /var/tmp/pp/ -on out && \
    qemu-system-x86_64 -machine accel=kvm:tcg -cpu max -m 2048 \
                       -drive file=/var/tmp/pp/out-sda,format=raw,if=virtio
```
and checked each guest booted without showing SELinux errors and I could log in.  (We should do more to automate this kind of testing.)

Thanks: Pavel Odvody
Fixes: https://redhat.atlassian.net/browse/RHEL-176189

@crobinso @berrange @sparimi-rh 